### PR TITLE
DS-163 - Update p2p-init.sh for macOS compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,18 @@ remote.it utilities useful in terminal based environments
 Demonstrates use of the remote.it connectd daemon on your Linux client to create a peer to peer 
 connection to a remote.it Service.
 This demo script is suitable for managing a small list (up to 25) of devices.
-It has been tested on Ubuntu and Raspbian.  At the moment it is not compatible with macOS.
+It has been tested on Ubuntu, Raspbian, and macOS Mojave.
+------------------------------------------
+### Prerequisite:
+Linux: make sure you have the connectd package installed first.  See: https://docs.remote.it/platforms/supported-platforms
+Mac: as we don't have a Mac package at this time, run the following commands in a terminal window to get the Mac version of the connectd daemon onto your system and create a symbolic link for the p2p-init.sh script to use:
 
+'''
+cd /usr/local/bin
+curl -LkO https://github.com/remoteit/connectd/releases/download/v4.6/connectd.x86_64-osx
+chmod +x connectd.x86_64-osx
+ln -s /usr/local/bin/connectd.x86_64-osx connectd
+'''
 ------------------------------------------
 Your username and authhash will be stored in ~/.remoteit/auth.  In the event of a "102] login failure" error, delete this file and try again.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ All:
 ./p2p-init.sh -l 
 ```
 ### To make a connection to an SSH service then log in, use:
-```
+```shell
 ./p2p-init.sh username@service-name
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ service-name is the name you gave to this device's SSH remote.it Service.
 If your service name has spaces in it, surround "username@device name" with quotes.
 
 For example. supposing your SSH service is called "My SSH Service" and the login username is pi, use:
-```
+```shell
 ./p2p-init.sh "pi@My SSH Service".
 ```
 When you log out of your ssh session, the P2P connection will be terminated.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ http/https:
 ```
 
 VNC:
-```
+```shell
 ./p2p-init.sh -p vnc -l 
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,14 @@ VNC:
 ```
 ./p2p-init.sh -p vnc -l 
 ```
+
+All:
+```
+./p2p-init.sh -l 
+```
 ### To make a connection to an SSH service then log in, use:
 ```
-./p2p-init.sh -p ssh username@service-name
+./p2p-init.sh username@service-name
 ```
 
 username is the ssh login name of the device.  For Raspberry Pi Raspbian OS, this is usually "pi".  
@@ -46,7 +51,7 @@ If your service name has spaces in it, surround "username@device name" with quot
 
 For example. supposing your SSH service is called "My SSH Service" and the login username is pi, use:
 ```
-./p2p-init.sh -p ssh "pi@My SSH Service".
+./p2p-init.sh "pi@My SSH Service".
 ```
 When you log out of your ssh session, the P2P connection will be terminated.
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ VNC:
 ```
 
 All:
-```
+```shell
 ./p2p-init.sh -l 
 ```
 ### To make a connection to an SSH service then log in, use:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Demonstrates use of the remote.it connectd daemon on your Linux client to create
 connection to a remote.it Service.
 This demo script is suitable for managing a small list (up to 25) of devices.
 It has been tested on Ubuntu, Raspbian, and macOS Mojave.
+
 \------------------------------------------
 ### Prerequisite:
 Linux: make sure you have the connectd package installed first.  See: https://docs.remote.it/platforms/supported-platforms

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It has been tested on Ubuntu, Raspbian, and macOS Mojave.
 Linux: make sure you have the connectd package installed first.  See: https://docs.remote.it/platforms/supported-platforms
 Mac: as we don't have a Mac package at this time, run the following commands in a terminal window to get the Mac version of the connectd daemon onto your system and create a symbolic link for the p2p-init.sh script to use:
 
-```
+```shell
 cd /usr/local/bin
 curl -LkO https://github.com/remoteit/connectd/releases/download/v4.6/connectd.x86_64-osx
 chmod +x connectd.x86_64-osx

--- a/README.md
+++ b/README.md
@@ -1,23 +1,23 @@
 # command-line
 remote.it utilities useful in terminal based environments
 
-------------------------------------------
+\------------------------------------------
 ## p2p-init.sh: remote.it Peer to Peer (P2P) initiator sample script.
 Demonstrates use of the remote.it connectd daemon on your Linux client to create a peer to peer 
 connection to a remote.it Service.
 This demo script is suitable for managing a small list (up to 25) of devices.
 It has been tested on Ubuntu, Raspbian, and macOS Mojave.
-------------------------------------------
+\------------------------------------------
 ### Prerequisite:
 Linux: make sure you have the connectd package installed first.  See: https://docs.remote.it/platforms/supported-platforms
 Mac: as we don't have a Mac package at this time, run the following commands in a terminal window to get the Mac version of the connectd daemon onto your system and create a symbolic link for the p2p-init.sh script to use:
 
-'''
+```
 cd /usr/local/bin
 curl -LkO https://github.com/remoteit/connectd/releases/download/v4.6/connectd.x86_64-osx
 chmod +x connectd.x86_64-osx
 ln -s /usr/local/bin/connectd.x86_64-osx connectd
-'''
+```
 ------------------------------------------
 Your username and authhash will be stored in ~/.remoteit/auth.  In the event of a "102] login failure" error, delete this file and try again.
 

--- a/p2p-init.sh
+++ b/p2p-init.sh
@@ -899,7 +899,7 @@ if [  -e $REMOTEIT_DIR/$port.active ]; then
         printf "Port ${port} is already active, connecting to existing tunnel.\n"
     fi
     # make serviceType upper case
-    connect_to_it "${SERVICE_PROTOCOL^^}"
+    connect_to_it "$(echo ${SERVICE_PROTOCOL} | awk '{ print toupper($0) }')"
     #
     echo "done"
 

--- a/p2p-init.sh
+++ b/p2p-init.sh
@@ -707,7 +707,7 @@ while getopts i:p:lvhmcr OPT; do
         ;;
       p)
         # convert input protocol string to upper case
-        serviceType=${OPTARG^^}
+	serviceType=$(echo ${OPTARG} | awk '{ print toupper($0) }')
         if [ "$serviceType" == "SSH" ]; then
             continue
         elif [ "$serviceType" == "HTTP" ]; then


### PR DESCRIPTION
Changed expression to make $OPTARG uppercase.  Tested on macOS and Ubuntu, works OK in both places.